### PR TITLE
fix(android): resolve app name disappearing after icon change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@howincodes/expo-dynamic-app-icon",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Programmatically change the app icon in Expo.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -180,7 +180,7 @@ const withIconAndroidManifest: ConfigPlugin<Props> = (config, { icons }) => {
               "android:enabled": "false",
               "android:exported": "true",
               "android:icon": iconResourceName,
-              "android:label": mainActivity.$["android:label"] || "",
+              "android:label": mainActivity.$["android:label"] || mainApplication.$["android:label"] || config.name || "",
               "android:targetActivity": ".MainActivity",
               "android:roundIcon": roundIconResourceName,
             },


### PR DESCRIPTION
## Summary

- Fixes #10 — app name disappears from launcher after changing icon on Android
- The `activity-alias` `android:label` was falling back to an empty string `""` when the `<activity>` tag had no explicit label (common in Expo apps where label is on `<application>`)
- Now uses the correct fallback chain: `activity label` → `application label` → `config.name`

## Root Cause

In `plugin/src/withDynamicIcon.ts`, the alias label was set as:
\`\`\`js
"android:label": mainActivity.$["android:label"] || ""
\`\`\`
When `mainActivity.$["android:label"]` is undefined (most Expo projects), Android uses the explicit empty string as the label — showing nothing in the launcher.

## Fix

\`\`\`js
"android:label": mainActivity.$["android:label"] || mainApplication.$["android:label"] || config.name || ""
\`\`\`

## Test plan

- [ ] Build Android app with dynamic icon plugin configured
- [ ] Change the app icon via `setAppIcon()`
- [ ] Return to home screen and verify app name is still visible